### PR TITLE
Adjust obligation level of attribute slots

### DIFF
--- a/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
+++ b/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
@@ -280,6 +280,7 @@ classes:
         range: DefinedTerm
         description: The type of quality that is quantifiable according to the QUDT ontology.
         slot_uri: qudt:hasQuantityKind
+        required: true
         bindings: ## new feature not yet implemented, see: https://github.com/linkml/linkml-model/releases/tag/v1.8.0
           - binds_value_of: id
             range: QUDTQuantityKindEnum

--- a/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
+++ b/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
@@ -289,6 +289,7 @@ classes:
       unit:
         slot_uri: qudt:unit
         range: DefinedTerm
+        recommended: true
         bindings: ## new feature not yet implemented, see: https://github.com/linkml/linkml-model/releases/tag/v1.8.0
           - binds_value_of: id
             range: QUDTUnitEnum

--- a/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
+++ b/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
@@ -263,7 +263,11 @@ classes:
       - title
       - description
       - value
-          
+    slot_usage:
+      value:
+        description: The slot to provide the literal value of the QualitativeAttribute.
+        required: true
+  
   QuantitativeAttribute:
     mixins:
       - ClassifierMixin
@@ -289,6 +293,10 @@ classes:
             range: QUDTUnitEnum
             obligation_level: RECOMMENDED
             description: Restricts the allowable defined terms to the QUDT Unit vocabulary.
+    slot_usage:
+      value:
+        description: The slot to provide the literal value of the QuantitativeAttribute.
+        required: true
 
         
 

--- a/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
+++ b/src/dcat_4c_ap/schema/dcat-4nfdi-ap.yaml
@@ -342,14 +342,14 @@ slots:
     description: The slot to specify the Method (aka Procedure) that was used in the ResearchActivity.
     range: Environment
   has_qualitative_attribute:
-    #slot_uri: dcterms:relation
+    slot_uri: dcterms:relation
     description: The slot to relate a qualitative attribute to an entity of interest, tool or environment.
     range: QualitativeAttribute
     inlined: true
     multivalued: true
     inlined_as_list: true
   has_quantitative_attribute:
-    #slot_uri: dcterms:relation
+    slot_uri: dcterms:relation
     description: The slot to relate a quantitative  attribute to an entity of interest, tool or environment.
     range: QuantitativeAttribute
     inlined: true


### PR DESCRIPTION
This PR add makes the following  slots required to be in line with my Draw.io diagram:
* the 'value' slot on 'QualitativeAttribute' & 'QuantitativeAttribute'
* the 'unit slot on 'QuantitativeAttribute'

It also maps the slots 'has_qualitative_attribute' & 'has_quantitative_attribute' to dcterms:relation in the base extention profile.