### PR TITLE
Added w3id based import statements to chem_dcat_ap schemas

### DIFF
--- a/src/chem_dcat_ap/schema/chem_dcat_ap.yaml
+++ b/src/chem_dcat_ap/schema/chem_dcat_ap.yaml
@@ -11,7 +11,10 @@ see_also:
   - https://github.com/HendrikBorgelt/DCAT-ap_as_LinkML_template/blob/main/src/dcatlinkml/schema/dcatlinkml.yaml
   - https://gitlab.com/opensourcelab/scientificdata/scidats/-/blob/feature/linkml-schemata/schemata/metadata_model_scidats_dcat_ap.yaml?ref_type=heads
 prefixes:
+  material_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/materials/
   chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
+  chemical_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/entity/
+  chemical_reaction_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/reaction/
   dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
@@ -59,8 +62,8 @@ default_range: string
 imports:
   - linkml:types
   - dcatapplus:latest/schema/dcat_ap_plus
-  - chemical_entities_ap
-  - chemical_reaction_ap
+  - chemical_entities_ap:latest/schema/chemical_entities_ap
+  - chemical_reaction_ap:latest/schema/chemical_reaction_ap
 
 classes:
 

--- a/src/chem_dcat_ap/schema/chemical_entities_ap.yaml
+++ b/src/chem_dcat_ap/schema/chemical_entities_ap.yaml
@@ -7,6 +7,7 @@ description: |-
 license: CC-BY 4.0
 prefixes:
   chemical_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/entity/
+  material_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/materials/
   chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
@@ -37,7 +38,7 @@ default_prefix: chemical_entities_ap
 default_range: string
 imports:
   - linkml:types
-  - material_entities_ap
+  - material_entities_ap:latest/schema/material_entities_ap
 
 classes:
 

--- a/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
+++ b/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
@@ -6,6 +6,7 @@ description: |-
   This is an application profile for chemical reactions that is intended to be used as an extension of DCAT-AP-PLUS.
 license: CC-BY 4.0
 prefixes:
+  material_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/materials/
   chemical_reaction_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/reaction/
   chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
   dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/
@@ -53,7 +54,7 @@ default_range: string
 imports:
   - linkml:types
   - dcatapplus:latest/schema/dcat_ap_plus
-  - chemical_entities_ap
+  - chemical_entities_ap:latest/schema/chemical_entities_ap
 
 classes:
 

--- a/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
+++ b/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
@@ -7,6 +7,7 @@ description: |-
 license: CC-BY 4.0
 prefixes:
   material_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/materials/
+  chemical_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/entity/
   chemical_reaction_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/reaction/
   chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
   dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/


### PR DESCRIPTION
This PR changes the Import statements in the chem_dcat_ap profiles, chem_dcat_ap, chemical_entites_ap, and chemical_reaction_ap (material_entites_ap was already changed via the last release).

This makes reusing the schema in another GitHub project simpler, since you don't need to have the subschemas stored in your local project.