### PR TITLE
modified the prefixes

### DIFF
--- a/src/chem_dcat_ap/schema/chem_dcat_ap.yaml
+++ b/src/chem_dcat_ap/schema/chem_dcat_ap.yaml
@@ -11,8 +11,8 @@ see_also:
   - https://github.com/HendrikBorgelt/DCAT-ap_as_LinkML_template/blob/main/src/dcatlinkml/schema/dcatlinkml.yaml
   - https://gitlab.com/opensourcelab/scientificdata/scidats/-/blob/feature/linkml-schemata/schemata/metadata_model_scidats_dcat_ap.yaml?ref_type=heads
 prefixes:
-  chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
-  dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/
+  chem_dcat_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
+  dcat_ap_plus: https://w3id.org/nfdi-de/dcat-ap-plus/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
   schema: http://schema.org/
@@ -40,25 +40,24 @@ prefixes:
   CHEMINF: http://semanticscience.org/resource/CHEMINF_
   RXNO: http://purl.obolibrary.org/obo/RXNO_
   MOP: http://purl.obolibrary.org/obo/MOP_
-  ex: http://example.org/
   NCIT: http://purl.obolibrary.org/obo/NCIT_
   SIO: http://semanticscience.org/resource/SIO_
   doi: https://doi.org/
   NMR: "http://nmrML.org/nmrCV#NMR:"
-  AFE: http://purl.allotrope.org/ontologies/equipment#AFE_
-  AFRL: http://purl.allotrope.org/ontologies/role#AFRL_
-  AFP: http://purl.allotrope.org/ontologies/process#AFP_
-  AFR: http://purl.allotrope.org/ontologies/result#AFR_
+  allotrope.equipment: http://purl.allotrope.org/ontologies/equipment#AFE_
+  allotrope.role: http://purl.allotrope.org/ontologies/role#AFRL_
+  allotrope.process: http://purl.allotrope.org/ontologies/process#AFP_
+  allotrope.result: http://purl.allotrope.org/ontologies/result#AFR_
   VOC4CAT: https://w3id.org/nfdi4cat/voc4cat_
   PROCO: http://purl.obolibrary.org/obo/PROCO_
   time: http://www.w3.org/2006/time#
   REX: http://purl.obolibrary.org/obo/REX_
   ENVO: http://purl.obolibrary.org/obo/ENVO_
-default_prefix: chemdcatap
+default_prefix: chem_dcat_ap
 default_range: string
 imports:
   - linkml:types
-  - dcatapplus:latest/schema/dcat_ap_plus
+  - dcat_ap_plus:latest/schema/dcat_ap_plus
   - chemical_entities_ap
   - chemical_reaction_ap
 

--- a/src/chem_dcat_ap/schema/chemical_entities_ap.yaml
+++ b/src/chem_dcat_ap/schema/chemical_entities_ap.yaml
@@ -7,7 +7,7 @@ description: |-
 license: CC-BY 4.0
 prefixes:
   chemical_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/entity/
-  chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
+  chem_dcat_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
   schema: http://schema.org/
@@ -22,14 +22,13 @@ prefixes:
   OBI: http://purl.obolibrary.org/obo/OBI_
   IAO: http://purl.obolibrary.org/obo/IAO_
   BFO: http://purl.obolibrary.org/obo/BFO_
-  ex: http://example.org/
   SIO: http://semanticscience.org/resource/SIO_
   doi: https://doi.org/
-  AFE: http://purl.allotrope.org/ontologies/equipment#AFE_
-  AFRL: http://purl.allotrope.org/ontologies/role#AFRL_
-  AFP: http://purl.allotrope.org/ontologies/process#AFP_
+  allotrope.equipment: http://purl.allotrope.org/ontologies/equipment#AFE_
+  allotrope.role: http://purl.allotrope.org/ontologies/role#AFRL_
+  allotrope.process: http://purl.allotrope.org/ontologies/process#AFP_
   AFX: http://purl.allotrope.org/ontologies/property#AFX_
-  AFR: http://purl.allotrope.org/ontologies/result#AFR_
+  allotrope.result: http://purl.allotrope.org/ontologies/result#AFR_
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   VOC4CAT: https://w3id.org/nfdi4cat/voc4cat_
   EDAM: http://edamontology.org/data_
@@ -98,7 +97,7 @@ classes:
 # QuantitativeAttributes #
 #########################
   MolarMass:
-    class_uri: AFR:0002409
+    class_uri: allotrope.result:0002409
     is_a: Mass
     description: A Mass (physical quality) that quantifies the mass of a homogeneous ChemicalSubstance containing 6.02 x 10^23 atoms or molecules.
     close_mappings:
@@ -111,7 +110,7 @@ classes:
       - EDAM:2140
       - NCIT:C41185
       - VOC4CAT:0007244
-      - AFR:0002036
+      - allotrope.result:0002036
     narrow_mappings:
       - CHMO:0002822
     close_mappings:
@@ -137,7 +136,7 @@ classes:
     class_uri: SIO:001089
     exact_mappings:
       - NCIT:C45997
-      - AFR:0001142
+      - allotrope.result:0001142
     close_mappings:
       - PATO:0001842
       #slot_usage:

--- a/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
+++ b/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
@@ -89,7 +89,7 @@ classes:
     exact_mappings:
       - MOP:0000543
       - REX:0000002
-      - AFP:0003711
+      - allotrope.process:0003711
     narrow_mappings:
       - RXNO:0000329
 
@@ -158,7 +158,7 @@ classes:
 
   Reactor:
     is_a: Device
-    class_uri: AFE:0000153
+    class_uri: allotrope.equipment:0000153
     mixins:
       - MaterialisticMixin
     description: A reactor is a container for controlling a biological or chemical reaction or process.

--- a/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
+++ b/src/chem_dcat_ap/schema/chemical_reaction_ap.yaml
@@ -7,8 +7,8 @@ description: |-
 license: CC-BY 4.0
 prefixes:
   chemical_reaction_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/reaction/
-  chemdcatap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
-  dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/
+  chem_dcat_ap: https://w3id.org/nfdi-de/dcat-ap-plus/chemistry/
+  dcat_ap_plus: https://w3id.org/nfdi-de/dcat-ap-plus/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
   schema: http://schema.org/
@@ -40,9 +40,9 @@ prefixes:
   SIO: http://semanticscience.org/resource/SIO_
   doi: https://doi.org/
   NMR: "http://nmrML.org/nmrCV#NMR:"
-  AFE: http://purl.allotrope.org/ontologies/equipment#AFE_
-  AFRL: http://purl.allotrope.org/ontologies/role#AFRL_
-  AFP: http://purl.allotrope.org/ontologies/process#AFP_
+  allotrope.equipment: http://purl.allotrope.org/ontologies/equipment#AFE_
+  allotrope.role: http://purl.allotrope.org/ontologies/role#AFRL_
+  allotrope.process: http://purl.allotrope.org/ontologies/process#AFP_
   VOC4CAT: https://w3id.org/nfdi4cat/voc4cat_
   PROCO: http://purl.obolibrary.org/obo/PROCO_
   time: http://www.w3.org/2006/time#
@@ -52,7 +52,7 @@ default_prefix: chemical_reaction_ap
 default_range: string
 imports:
   - linkml:types
-  - dcatapplus:latest/schema/dcat_ap_plus
+  - dcat_ap_plus:latest/schema/dcat_ap_plus
   - chemical_entities_ap
 
 classes:

--- a/src/chem_dcat_ap/schema/material_entities_ap.yaml
+++ b/src/chem_dcat_ap/schema/material_entities_ap.yaml
@@ -7,7 +7,7 @@ description: |-
 license: CC-BY 4.0
 prefixes:
   material_entities_ap: https://w3id.org/nfdi-de/dcat-ap-plus/materials/
-  dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/
+  dcat_ap_plus: https://w3id.org/nfdi-de/dcat-ap-plus/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
   schema: http://schema.org/
@@ -22,18 +22,17 @@ prefixes:
   OBI: http://purl.obolibrary.org/obo/OBI_
   IAO: http://purl.obolibrary.org/obo/IAO_
   BFO: http://purl.obolibrary.org/obo/BFO_
-  ex: http://example.org/
   SIO: http://semanticscience.org/resource/SIO_
   doi: https://doi.org/
-  AFE: http://purl.allotrope.org/ontologies/equipment#AFE_
-  AFRL: http://purl.allotrope.org/ontologies/role#AFRL_
-  AFP: http://purl.allotrope.org/ontologies/process#AFP_
+  allotrope.equipment: http://purl.allotrope.org/ontologies/equipment#AFE_
+  allotrope.role: http://purl.allotrope.org/ontologies/role#AFRL_
+  allotrope.process: http://purl.allotrope.org/ontologies/process#AFP_
   VOC4CAT: https://w3id.org/nfdi4cat/voc4cat_
 default_prefix: material_entities_ap
 default_range: string
 imports:
   - linkml:types
-  - dcatapplus:latest/schema/dcat_ap_plus
+  - dcat_ap_plus:latest/schema/dcat_ap_plus
 
 classes:
   MaterialisticMixin:

--- a/tests/data/valid/ChemicalReaction-001.yaml
+++ b/tests/data/valid/ChemicalReaction-001.yaml
@@ -205,7 +205,7 @@ used_reactant:
       - value: "Glacial"
         title: "Grade/Purity"
         rdf_type:
-          id: AFR:0002371
+          id: allotrope.result:0002371
           title: "purity"
     composed_of:
       - id: https://pubchem.ncbi.nlm.nih.gov/compound/176

--- a/tests/data/valid/ReactionMonitoringDataset-001.yaml
+++ b/tests/data/valid/ReactionMonitoringDataset-001.yaml
@@ -244,7 +244,7 @@ is_about_activity:
           - value: "Glacial"
             title: "Grade/Purity"
             rdf_type:
-              id: AFR:0002371
+              id: allotrope.result:0002371
               title: "purity"
         composed_of:
           - id: https://pubchem.ncbi.nlm.nih.gov/compound/176


### PR DESCRIPTION
Changed:
- dcatapplus to dcat_ap_plus
- chemdcatap to chem_dcat_ap

and modified some of the prefixes as seen in nfdi-de/dcat-ap-plus#83

The tests should fail, because the prefix change on nfdi-de/dcat-ap-plus has not been rolled out yet, and therefore, the schema can't align the prefix mismatch